### PR TITLE
Fix missing "new" tag in lt_app_start metric

### DIFF
--- a/src/lotustracker.cpp
+++ b/src/lotustracker.cpp
@@ -75,7 +75,9 @@ LotusTracker::LotusTracker(int& argc, char **argv): QApplication(argc, argv),
 #elif defined Q_OS_WIN
     WinAutoStart::setEnabled(APP_SETTINGS->isAutoStartEnabled());
 #endif
-    if (APP_SETTINGS->isFirstRun()) {
+    // store in a variable, as reading this will clear the first run flag
+    bool isFirstRun = APP_SETTINGS->isFirstRun();
+    if (isFirstRun) {
         startScreen->show();
         startScreen->raise();
         showMessage(tr("Lotus Tracker is running in background, you can click on tray icon for preferences."));
@@ -95,7 +97,7 @@ LotusTracker::LotusTracker(int& argc, char **argv): QApplication(argc, argv),
     influx_metric(influxdb_cpp::builder()
         .meas("lt_app_start")
         .tag("autostart", APP_SETTINGS->isAutoStartEnabled() ? "true" : "false")
-        .tag("new", APP_SETTINGS->isFirstRun() ? "true" : "false")
+        .tag("new", isFirstRun ? "true" : "false")
         .field("count", 1)
     );
 }


### PR DESCRIPTION
As reading `APP_SETTINGS->isFirstRun` clears the new first run itself, all subsequent calls will always return false. This PR ensures that we locally store the first run state in order to correctly set the "new" tag on the lt_app_start metric.

This should fix Influx not recording a single instance of a "new" install in the last week.

I have not compiled or tested this yet.